### PR TITLE
Replace brackets with quotes in README

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -9,8 +9,8 @@ npm install
 
 # For security, you must configure http://localhost:8000/callback as a redirect uri in Smartcar's developer portal.
 PORT=8000 \
-SMARTCAR_CLIENT_ID=[CLIENT_ID] \
-SMARTCAR_SECRET=[CLIENT_SECRET] \
+SMARTCAR_CLIENT_ID="CLIENT_ID" \
+SMARTCAR_SECRET="CLIENT_SECRET" \
 SMARTCAR_REDIRECT_URI=http://localhost:8000/callback \
 SMARTCAR_MODE=development \
 node app.js

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartcar-node-demo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A sample app for the Smartcar API.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Displaying client id as "[CLIENT_ID]" has caused some users to replace just "CLIENT_ID" rather than replacing the brackets as well.