### PR TITLE
Update demo app to use live & test mode

### DIFF
--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.idea

--- a/node/app.js
+++ b/node/app.js
@@ -31,14 +31,14 @@ if (!validator.isUUID(SMARTCAR_SECRET)) {
 const SMARTCAR_REDIRECT_URI = envvar.string('SMARTCAR_REDIRECT_URI', `http://localhost:${PORT}/callback`);
 
 // Setting MODE to "development" will show Smartcar's mock vehicle
-const SMARTCAR_MODE = envvar.oneOf('SMARTCAR_MODE', ['development', 'production'], 'production');
+const SMARTCAR_MODE = envvar.oneOf('SMARTCAR_MODE', ['test', 'live'], 'test');
 
 // Initialize Smartcar client
 const client = new smartcar.AuthClient({
   clientId: SMARTCAR_CLIENT_ID,
   clientSecret: SMARTCAR_SECRET,
   redirectUri: SMARTCAR_REDIRECT_URI,
-  development: SMARTCAR_MODE === 'development',
+  testMode: SMARTCAR_MODE === 'test',
 });
 
 /**
@@ -66,6 +66,7 @@ app.get('/', function(req, res, next) {
 
   res.render('home', {
     authUrl: client.getAuthUrl(),
+    testMode: SMARTCAR_MODE === 'test',
   });
 
 });

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartcar-node-demo",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "A sample app for the Smartcar API.",
   "main": "app.js",
   "scripts": {
@@ -28,7 +28,7 @@
     "express-handlebars": "^3.0.0",
     "lodash": "^4.17.10",
     "opn": "^5.3.0",
-    "smartcar": "^3.0.1",
+    "smartcar": "^4.1.0",
     "url": "^0.11.0",
     "validator": "^10.6.0"
   }

--- a/node/views/home.hbs
+++ b/node/views/home.hbs
@@ -3,5 +3,19 @@
   <p>
     The first step is to connect to a vehicle using Smartcar's authorization flow. Clicking "Connect your car" below will redirect to Smartcar, allowing you to authenticate with a Smartcar-supported vehicle.
   </p>
-  <button type="button" class="btn btn-primary" onclick="window.location.href='{{authUrl}}'">Connect your car</button>
+  <button type="button" class="btn btn-primary" onclick="window.location.href='{{authUrl}}'">
+    {{#if testMode}}
+      Connect to a test car
+    {{else}}
+      Connect to your car
+    {{/if}}
+  </button>
+  <p/>
+  <p>
+    {{#if testMode}}
+      Want to test on a real vehicle? Run the demo in <a href="https://smartcar.com/docs#test-mode">live mode</a>.
+    {{else}}
+      Don't have access to a car? You can connect to a test vehicle using our <a href="https://smartcar.com/docs#test-mode">test mode</a>.
+    {{/if}}
+  </p>
 </div>


### PR DESCRIPTION
## Changes
Update demo app so it can be run in [live & test mode](https://smartcar.com/docs#test-mode).

## Notes
The AuthClient in the Node SDK does not support passing a `testMode` option to the `client.getAuthUrl()` method. I will update the demo to have two buttons (real car, test car) after I make that change to the Node SDK.